### PR TITLE
add simple parallel pandoc implementation

### DIFF
--- a/src/md/utils.nim
+++ b/src/md/utils.nim
@@ -73,7 +73,7 @@ proc prepareCache*(workingDir, courseDir: string; ignoreDirs: openArray[string])
 
       blockResult
 
-    cacheTable = collect(for k, v in cacheFiles.groupBy(extractFilename): (k, v)).toTable
+    cacheTable = collect(for k, v in cacheFiles.groupBy((s) => extractFilename(s)): (k, v)).toTable
 
   result.files = cacheFiles
   result.table = cacheTable

--- a/src/nim.cfg
+++ b/src/nim.cfg
@@ -1,1 +1,1 @@
--d:release
+-d:release --mm:orc -d:danger

--- a/src/parallel.nim
+++ b/src/parallel.nim
@@ -1,0 +1,74 @@
+
+# Utilities for running pandoc jobs in parallel
+
+import std/
+  [ logging
+  , os
+  , osproc
+  , strformat
+  , strutils
+  , streams
+  ]
+import md/
+  [ preprocess
+  , utils
+  ]
+import customlogger, types
+
+
+type
+  PandocRunner* = object
+    settings: AppSettings
+    processes: seq[tuple[fileIn: string, process: Process]]
+
+
+proc init*(_: typedesc[PandocRunner], settings: AppSettings): PandocRunner =
+  result.settings = settings
+
+
+proc addJob*(runner: var PandocRunner, fileIn, fileOut, fileInContents, pandocAssetsCmdOptions: string) =
+  ## Add a pandoc job to the queue
+  createDir(fileOut.parentDir)
+  info fmt"Creating output `{fileOut.parentDir}` directory..."
+
+  let cmd = [ runner.settings.pandocExe
+            , "--self-contained"
+            , "--resource-path=\"{fileIn.parentDir}\"".fmt
+            , "--metadata=title:\"{fileOut.splitFile.name}\"".fmt
+            , "--output=\"{fileOut}\"".fmt
+            , pandocAssetsCmdOptions
+            , "-"
+            ].join(SPACE)
+
+  let
+    processOptions = if logger.levelThreshold == lvlAll: {poEchoCmd, poStdErrToStdOut, poUsePath, poEvalCommand} else: {poStdErrToStdOut, poUsePath, poEvalCommand}
+    process = startProcess(cmd, options=processOptions)
+
+  let input = preprocess(fileIn, fileInContents)
+
+  process.inputStream.write input
+  process.inputStream.flush()
+  process.inputStream.close()
+
+  runner.processes.add (fileIn, process)
+
+
+proc waitForJobs*(runner: PandocRunner, report: var Report) =
+  ## wait until all jobs are finished, then display all statuses and update the report
+  for job in runner.processes:
+    var outputFile: File
+    discard outputFile.open(job.process.outputHandle, fmRead)
+    let
+      output = outputFile.readAll()
+      exitCode = job.process.waitForExit()
+
+    outputFile.close()
+    job.process.close()
+
+    if exitCode == QuitSuccess:
+      report.built.inc
+      if output.strip != "":
+        info [fmt"`{job.fileIn.relativePath(runner.settings.workingDir)}`", "{output}".fmt].join(NL)
+    else:
+      report.errors.inc
+      error [fmt"`{job.fileIn.relativePath(runner.settings.workingDir)}`", "{output.strip}".fmt, "Skipping..."].join(NL)

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,0 +1,14 @@
+
+
+type AppSettings* = object
+  inputDir*: string
+  workingDir*: string
+  courseDir*: string
+  distDir*: string
+  godotProjectDirs*: seq[string]
+  ignoreDirs*: seq[string]
+  pandocExe*: string
+  pandocAssetsDir*: string
+  isCleaning*: bool
+  isForced*: bool
+  exec*: seq[string]


### PR DESCRIPTION
This PR changes the way the app calls out to pandoc for processing files. Previously all pandoc calls were sequential, they are now run in parallel as soon as the file has been preprocessed.

The aim was to keep the changes simple and minimal. A part of the `process` proc in `buildcourse.nim` has been moved to a new module called `parallel`. A new type `PandocRunner` was introduced to keep track of the running pandoc calls. The `AppSettings` type definition was moved to a new shared types module called `types.nim`.

In the future if courses get large enough we may want to consider limiting the amount of concurrent pandoc calls. When testing I did not find this to be an issue at the moment.

I also added the `--mm:orc` and `-d:danger` compiler flags which also gained some speed. The output of the program has been diff'd with the original output to ensure correctness.

This cuts the average runtime of the app down 50-75%.